### PR TITLE
Fix client trying to resubmit failed scores.

### DIFF
--- a/handlers/submitModularHandler.pyx
+++ b/handlers/submitModularHandler.pyx
@@ -731,7 +731,7 @@ class handler(requestsManager.asyncRequestHandler):
 				self.write(output)
 			else:
 				# No ranking panel, send just "ok"
-				self.write("ok")
+				self.write("error: no")
 
 			# Send username change request to bancho if needed
 			# (key is deleted bancho-side)


### PR DESCRIPTION
The "ok" makes the client confused, causing it to ressubmit failed scores multiple times. Here is a screenshot of before and after (below red line is before) from RealistikOsu where I added the same fix.
![image](https://user-images.githubusercontent.com/36131887/113285009-56b68b00-92e2-11eb-89b0-77482fc8a371.png)
